### PR TITLE
Bump the version of mirror-proxy

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -7,7 +7,7 @@
   - host: /tmp/jenkins
     container: /var/jenkins_home
 - name: jenkins-mirror-proxy
-  image: docker.io/jenkinszh/mirror-proxy:dev-bea8325
+  image: docker.io/jenkinszh/mirror-proxy:dev-8d6c377
   volumes:
   - host: /var/rootCA
     container: /rootCA


### PR DESCRIPTION
Add support to download the metadata info of tools in Jenkins